### PR TITLE
Add request parameters

### DIFF
--- a/aa/ca.py
+++ b/aa/ca.py
@@ -69,7 +69,7 @@ class CaFetcher(Fetcher):
         """
         self._client = CaClient(url)
 
-    def _get_values(self, pv, start, end=None, count=None):
+    def _get_values(self, pv, start, end=None, count=None, request_params=None):
         # Make count a large number if not specified to ensure we get all
         # data.
         count = 2**31 if count is None else count

--- a/aa/fetcher.py
+++ b/aa/fetcher.py
@@ -10,10 +10,10 @@ from . import utils
 class Fetcher(object):
     """Abstract base class for fetching data from an archiver."""
 
-    def _get_values(self, pv, start, end, count):
+    def _get_values(self, pv, start, end, count, request_params):
         raise NotImplementedError()
 
-    def get_values(self, pv, start, end=None, count=None):
+    def get_values(self, pv, start, end=None, count=None, request_params=None):
         """Retrieve archive data.
 
         start and end are datetime objects. If they are not timezone aware,
@@ -26,6 +26,7 @@ class Fetcher(object):
                 events to the current time
             count: maximum number of events to return. If None, return all
                 events
+            request_params: Settings dictionary used for archiver request
 
         Returns:
             ArchiveData object representing all events
@@ -38,9 +39,9 @@ class Fetcher(object):
                 end = utils.add_local_timezone(end)
         else:
             end = utils.add_local_timezone(datetime.now())
-        return self._get_values(pv, start, end, count)
+        return self._get_values(pv, start, end, count, request_params)
 
-    def get_event_at(self, pv, instant):
+    def get_event_at(self, pv, instant, request_params=None):
         """Retrieve the event preceding the specified datetime.
 
         If instant is not timezone aware, assume that it is in the local
@@ -49,6 +50,7 @@ class Fetcher(object):
         Args:
             pv: PV to request event for
             instant: datetime of the requested event
+            request_params: Settings dictionary used for archiver request
 
         Returns:
             ArchiveEvent representing the event preceding the requested
@@ -58,7 +60,8 @@ class Fetcher(object):
         if instant.tzinfo is None:
             instant = utils.add_local_timezone(instant)
         try:
-            return self.get_values(pv, instant, instant, 1).get_event(0)
+            return self.get_values(pv, instant, instant, 1,
+                                   request_params).get_event(0)
         except IndexError:
             error_msg = 'No data found for pv {} at timestamp {}'
             raise ValueError(error_msg.format(pv, instant))
@@ -90,20 +93,27 @@ class AaFetcher(Fetcher):
         assert dt.tzinfo is not None
         return dt.astimezone(pytz.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
-    def _construct_url(self, pv, start, end):
+    def _construct_url(self, pv, start, end, request_params):
+        if request_params is None:
+            request_params = {}
+
         suffix = '?pv={}&from={}&to={}'.format(
             pv,
             self._format_datetime(start),
             self._format_datetime(end)
         )
+
+        for key, value in request_params.iteritems():
+            suffix += "&{}={}".format(key, value)
+
         return '{}{}'.format(self._url, suffix)
 
-    def _fetch_data(self, pv, start, end):
-        url = self._construct_url(pv, start, end)
+    def _fetch_data(self, pv, start, end, request_params):
+        url = self._construct_url(pv, start, end, request_params)
         return requests.get(url, stream=self._binary)
 
-    def _get_values(self, pv, start, end, count):
-        response = self._fetch_data(pv, start, end)
+    def _get_values(self, pv, start, end, count, request_params=None):
+        response = self._fetch_data(pv, start, end, request_params)
         response.raise_for_status()
         return self._parse_raw_data(response, pv, start, end, count)
 

--- a/aa/fetcher.py
+++ b/aa/fetcher.py
@@ -112,7 +112,7 @@ class AaFetcher(Fetcher):
         url = self._construct_url(pv, start, end, request_params)
         return requests.get(url, stream=self._binary)
 
-    def _get_values(self, pv, start, end, count, request_params=None):
+    def _get_values(self, pv, start, end, count, request_params):
         response = self._fetch_data(pv, start, end, request_params)
         response.raise_for_status()
         return self._parse_raw_data(response, pv, start, end, count)

--- a/aa/fetcher.py
+++ b/aa/fetcher.py
@@ -103,7 +103,7 @@ class AaFetcher(Fetcher):
             self._format_datetime(end)
         )
 
-        for key, value in request_params.iteritems():
+        for key, value in request_params.items():
             suffix += "&{}={}".format(key, value)
 
         return '{}{}'.format(self._url, suffix)

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -167,7 +167,7 @@ class PbFetcher(fetcher.AaFetcher):
         super(PbFetcher, self).__init__(hostname, port, binary=True)
         self._url = '{}/retrieval/data/getData.raw'.format(self._endpoint)
 
-    def _get_values(self, pv, start, end, count, request_params=None):
+    def _get_values(self, pv, start, end, count, request_params):
         try:
             return super(PbFetcher, self)._get_values(pv, start, end, count,
                                                       request_params)

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -167,9 +167,10 @@ class PbFetcher(fetcher.AaFetcher):
         super(PbFetcher, self).__init__(hostname, port, binary=True)
         self._url = '{}/retrieval/data/getData.raw'.format(self._endpoint)
 
-    def _get_values(self, pv, start, end, count):
+    def _get_values(self, pv, start, end, count, request_params=None):
         try:
-            return super(PbFetcher, self)._get_values(pv, start, end, count)
+            return super(PbFetcher, self)._get_values(pv, start, end, count,
+                                                      request_params)
         except requests.exceptions.HTTPError as e:
             # Not found typically means no data for the PV in this time range.
             if e.response.status_code == 404:
@@ -209,7 +210,7 @@ class PbFileFetcher(fetcher.Fetcher):
                 log.warning('No pb file {} found')
         return parse_pb_data(bytes(raw_data), pv, start, end, count)
 
-    def _get_values(self, pv, start, end=None, count=None):
+    def _get_values(self, pv, start, end=None, count=None, request_params=None):
         pb_files = []
         for year in range(start.year, end.year + 1):
             pb_files.append(self._get_pb_file(pv, year))

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from datetime import datetime
 
 import mock
@@ -58,7 +59,9 @@ def test_AaFetcher_constructs_url_correctly(dummy_pv, aa_fetcher):
         assert mock_get.call_args[0][0] == expected
         mock_get.reset_mock()
 
-        request_params = {"param1Name": "param1Value", "param2Name": "param2Value"}
+        request_params = OrderedDict()
+        request_params["param1Name"] = "param1Value"
+        request_params["param2Name"] = "param2Value"
         aa_fetcher.get_values(dummy_pv, early, late, None, request_params)
         expected += '&param1Name=param1Value&param2Name=param2Value'
         assert mock_get.call_args[0][0] == expected

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -48,11 +48,20 @@ def test_AaFetcher_format_datetime(aa_fetcher):
 
 def test_AaFetcher_constructs_url_correctly(dummy_pv, aa_fetcher):
     aa_fetcher._url = 'dummy-url'
+    aa_fetcher._parse_raw_data = mock.MagicMock()
     early = pytz.utc.localize(EARLY_DATE)
     late = pytz.utc.localize(LATE_DATE)
-    constructed = aa_fetcher._construct_url(dummy_pv, early, late)
-    expected = 'dummy-url?pv=dummy&from=2001-01-01T01:01:00Z&to=2010-02-03T04:05:00Z'
-    assert constructed == expected
+
+    with mock.patch('requests.get') as mock_get:
+        aa_fetcher.get_values(dummy_pv, early, late, None)
+        expected = 'dummy-url?pv=dummy&from=2001-01-01T01:01:00Z&to=2010-02-03T04:05:00Z'
+        assert mock_get.call_args[0][0] == expected
+        mock_get.reset_mock()
+
+        request_params = {"param1Name": "param1Value", "param2Name": "param2Value"}
+        aa_fetcher.get_values(dummy_pv, early, late, None, request_params)
+        expected += '&param1Name=param1Value&param2Name=param2Value'
+        assert mock_get.call_args[0][0] == expected
 
 
 def test_AaFetcher_creates_default_for_end_if_not_provided(dummy_pv, aa_fetcher):


### PR DESCRIPTION
The Fetcher class now provides the ability to set additional parameters used during archiver retrieval. This has been used by the AaFetcher (Archiver Appliance) subclass, in particular.

The motivation for this was to enable the retiredPVTemplate parameter to be set for Archiver Appliance retrieval.

I have also modified the unit test that checks the url construction to use the public method 'get_values', as I thought it better to test the public interface. Please let me know your opinion on this.