### PR TITLE
Check that answer contains data

### DIFF
--- a/aa/js.py
+++ b/aa/js.py
@@ -19,7 +19,7 @@ class JsonFetcher(fetcher.AaFetcher):
         json_data = response.json()
         archive_data = data.ArchiveData.empty(pv)
 
-        if json_data:
+        if json_data and 'data' in json_data[0]:
             events = []
             json_events = json_data[0]['data']
             for json_event in json_events:


### PR DESCRIPTION
This is Emilio's branch from Gitlab, rebased and to merge into master. Original description:

In a very few cases, there will be an answer without the data field, these cases will raise an exception.
This change intends to make it obtain an empty result instead of an exception.

