### PR TITLE
Boring packaging stuff

### DIFF
--- a/aa/__init__.py
+++ b/aa/__init__.py
@@ -1,31 +1,27 @@
 """Python client to the EPICS Archiver Appliance."""
-import logging
-
-import pytz
-import tzlocal
 
 from aa._version_git import __version__
 
-__all__ = [__version__]
+from . import ca, data, fetcher, js, pb, rest, storage, utils
 
-SCAN = "SCAN"
-MONITOR = "MONITOR"
+# Below moved to utils but maintain API compat
+from .utils import LOCALTZ, LOG_FORMAT, LOG_LEVEL, MONITOR, SCAN, UTC, set_up_logging
 
-# Make UTC and local timezone easy to get hold of.
-LOCALTZ = tzlocal.get_localzone()
-UTC = pytz.utc
-
-# Logging utilities
-LOG_FORMAT = "%(asctime)s %(levelname)-8s %(message)s"
-LOG_LEVEL = logging.DEBUG
-
-
-def set_up_logging(fmt=LOG_FORMAT, level=LOG_LEVEL):
-    """Simple logging setup.
-
-    Args:
-        fmt: logging format to use
-        level: logging level to use
-
-    """
-    logging.basicConfig(format=fmt, level=level, datefmt="%Y-%m-%d %I:%M:%S")
+__all__ = [
+    "__version__",
+    "ca",
+    "data",
+    "fetcher",
+    "js",
+    "pb",
+    "rest",
+    "storage",
+    "utils",
+    "SCAN",
+    "MONITOR",
+    "LOCALTZ",
+    "UTC",
+    "LOG_FORMAT",
+    "LOG_LEVEL",
+    "set_up_logging",
+]

--- a/aa/__init__.py
+++ b/aa/__init__.py
@@ -1,8 +1,7 @@
 """Python client to the EPICS Archiver Appliance."""
 
-from aa._version_git import __version__
-
 from . import ca, data, fetcher, js, pb, rest, storage, utils
+from ._version_git import __version__
 
 # Below moved to utils but maintain API compat
 from .utils import LOCALTZ, LOG_FORMAT, LOG_LEVEL, MONITOR, SCAN, UTC, set_up_logging

--- a/aa/ca.py
+++ b/aa/ca.py
@@ -7,6 +7,11 @@ import numpy
 from aa import data, utils
 from aa.fetcher import Fetcher
 
+__all__ = [
+    "CaClient",
+    "CaFetcher",
+]
+
 
 class CaClient(object):
     """Class to handle XMLRPC interaction with a channel archiver."""

--- a/aa/ca.py
+++ b/aa/ca.py
@@ -4,8 +4,8 @@ from xmlrpc.client import ServerProxy
 
 import numpy
 
-from aa import data, utils
-from aa.fetcher import Fetcher
+from . import data, utils
+from .fetcher import Fetcher
 
 __all__ = [
     "CaClient",

--- a/aa/data.py
+++ b/aa/data.py
@@ -6,6 +6,13 @@ import pytz
 
 from . import utils
 
+__all__ = [
+    "ArchiveEvent",
+    "ArchiveData",
+    "data_from_events",
+]
+
+
 DIFFERENT_PV_ERROR = "All concatenated ArchiveData objects must have the same PV name"
 TIMESTAMP_WARNING = "Timestamps not monotonically increasing: {} -> {}"
 

--- a/aa/fetcher.py
+++ b/aa/fetcher.py
@@ -6,6 +6,11 @@ import requests
 
 from . import utils
 
+__all__ = [
+    "Fetcher",
+    "AaFetcher",
+]
+
 
 class Fetcher(object):
     """Abstract base class for fetching data from an archiver."""

--- a/aa/js.py
+++ b/aa/js.py
@@ -1,5 +1,5 @@
 """Class for fetching data from the Archiver Appliance using JSON."""
-from aa import data, fetcher
+from . import data, fetcher
 
 __all__ = ["JsonFetcher"]
 

--- a/aa/js.py
+++ b/aa/js.py
@@ -1,6 +1,8 @@
 """Class for fetching data from the Archiver Appliance using JSON."""
 from aa import data, fetcher
 
+__all__ = ["JsonFetcher"]
+
 
 class JsonFetcher(fetcher.AaFetcher):
     """Class to fetch data from the Archiver Appliance using JSON."""

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -33,6 +33,20 @@ from . import data
 from . import epics_event_pb2 as ee
 from . import fetcher, utils
 
+__all__ = [
+    "unescape_bytes",
+    "escape_bytes",
+    "event_timestamp",
+    "search_events",
+    "break_up_chunks",
+    "event_from_line",
+    "parse_pb_data",
+    "PbFetcher",
+    "PbFileFetcher",
+    "get_iso_timestamp_for_event",
+]
+
+
 # It is not clear to me why I can't extract this information
 # from the compiled protobuf file.
 TYPE_MAPPINGS = {

--- a/aa/rest.py
+++ b/aa/rest.py
@@ -1,7 +1,9 @@
 """Class for making calls to the Archiver Appliance Rest API."""
 import requests
 
-import aa
+from .utils import MONITOR, SCAN
+
+__all__ = ["AaRestClient"]
 
 
 class AaRestClient(object):
@@ -88,8 +90,8 @@ class AaRestClient(object):
         pv_info = self._rest_get("getCurrentlyDisconnectedPVs")
         return set([info["pvName"] for info in pv_info])
 
-    def archive_pv(self, pv, samplingperiod, samplingmethod=aa.SCAN):
-        if samplingmethod not in [aa.SCAN, aa.MONITOR]:
+    def archive_pv(self, pv, samplingperiod, samplingmethod=SCAN):
+        if samplingmethod not in [SCAN, MONITOR]:
             raise ValueError("Sampling method {} not valid".format(samplingmethod))
         return self._rest_get(
             "archivePV",
@@ -110,7 +112,7 @@ class AaRestClient(object):
     def abort_archiving_pv(self, pv):
         return self._rest_get("abortArchivingPV", pv=pv)
 
-    def change_archival_parameters(self, pv, period, method=aa.MONITOR):
+    def change_archival_parameters(self, pv, period, method=MONITOR):
         return self._rest_get(
             "changeArchivalParameters",
             pv=pv,

--- a/aa/storage.py
+++ b/aa/storage.py
@@ -1,3 +1,9 @@
+__all__ = [
+    "ParsingError",
+    "pv_name_from_path",
+]
+
+
 class ParsingError(Exception):
     pass
 

--- a/aa/utils.py
+++ b/aa/utils.py
@@ -7,6 +7,18 @@ from datetime import datetime
 import pytz
 import tzlocal
 
+__all__ = [
+    "utc_datetime",
+    "utc_now",
+    "EPOCH",
+    "datetime_to_epoch",
+    "epoch_to_datetime",
+    "add_local_timezone",
+    "year_timestamp",
+    "print_raw_bytes",
+    "binary_search",
+]
+
 
 def utc_datetime(*args):
     # pylint: disable=no-value-for-parameter
@@ -86,3 +98,26 @@ def binary_search(seq, f, target):
         elif next_val <= target:
             lower = current
     return upper
+
+
+SCAN = "SCAN"
+MONITOR = "MONITOR"
+
+# Make UTC and local timezone easy to get hold of.
+LOCALTZ = tzlocal.get_localzone()
+UTC = pytz.utc
+
+# Logging utilities
+LOG_FORMAT = "%(asctime)s %(levelname)-8s %(message)s"
+LOG_LEVEL = logging.DEBUG
+
+
+def set_up_logging(fmt=LOG_FORMAT, level=LOG_LEVEL):
+    """Simple logging setup.
+
+    Args:
+        fmt: logging format to use
+        level: logging level to use
+
+    """
+    logging.basicConfig(format=fmt, level=level, datefmt="%Y-%m-%d %I:%M:%S")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,9 @@
+# flake8: noqa
+
+from aa import *
+
+
+def test_module_import_star():
+    # Check a random selection of things exist in the namespace
+    # from the start import above
+    assert all([SCAN, MONITOR, js, pb, data, fetcher, utils])


### PR DESCRIPTION
Implement recommended pattern in __init__.py
    Add __all__ definitions to each module. Import each module in
    __init__.py and define a top-level __all__.
    Move other defs from __init__.py into utils to avoid circular
    imports, but keep them in global __all__ to not break exisitng
    uses.

Change all imports to relative
