### PR TITLE
Override default codecov behaviour

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        # Don't fail CI based on coverage
+        informational: true
+


### PR DESCRIPTION
Don't fail CI if codecov thinks coverage will go down or has a problem with a particular diff.