### PR TITLE
Get enum strings where available

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -38,7 +38,7 @@ aapy = {editable = true,path = "."}
 
 [scripts]
 tests = "python -m pytest"
-docs = "sphinx-build -EWT --keep-going docs build/html"
+docs = "sphinx-build -ET --keep-going docs build/html"
 build = "python setup.py sdist bdist_wheel"
 # Delete any files that git ignore hides from us
 gitclean = "git clean -fdX"

--- a/aa/fetcher.py
+++ b/aa/fetcher.py
@@ -101,6 +101,9 @@ class AaFetcher(Fetcher):
         if request_params is None:
             request_params = {}
 
+        # Gets values for all fields. Enables us to give string labels for enums.
+        request_params["fetchLatestMetadata"] = "true"
+
         suffix = "?pv={}&from={}&to={}".format(
             pv, self._format_datetime(start), self._format_datetime(end)
         )

--- a/aa/js.py
+++ b/aa/js.py
@@ -32,6 +32,12 @@ class JsonFetcher(fetcher.AaFetcher):
                     )
                 )
 
-            archive_data = data.data_from_events(pv, events)
+            enum_options = (
+                data.parse_enum_options(json_data[0]["meta"])
+                if "meta" in json_data[0]
+                else {}
+            )
+
+            archive_data = data.data_from_events(pv, events, enum_options=enum_options)
 
         return archive_data

--- a/tests/data/enum_event.json
+++ b/tests/data/enum_event.json
@@ -1,0 +1,30 @@
+[ 
+  { "meta":
+    {
+      "name": "CS-CS-MSTAT-01:MODE",
+      "DRVH": "0.0",
+      "ENUM_1": "Injection",
+      "HIGH": "0.0",
+      "HIHI": "0.0",
+      "ENUM_0": "Shutdown",
+      "DRVL": "0.0",
+      "ENUM_3": "Mach. Dev.",
+      "PREC": "0.0",
+      "LOLO": "0.0",
+      "ENUM_2": "No Beam",
+      "LOPR": "0.0",
+      "ENUM_5": "Special",
+      "ENUM_4": "User",
+      "HOPR": "0.0",
+      "ENUM_7": "Unknown", 
+      "ENUM_6": "BL Startup",
+      "LOW": "0.0",
+      "NELM": "1" 
+    },
+  "data": 
+    [ 
+      { "secs": 1625883918, "val": 4, "nanos": 89023701, "severity":0, "status":0 }
+    ]
+  }
+]
+  

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -43,7 +43,6 @@ def test_CaClient_create_archive_event_handles_2d_event(ca_client, dummy_pv, eve
 
 
 def test_CaClient_get_returns_event(ca_client, dummy_pv, event_1d):
-    print(ca_client)
     with mock.patch("aa.utils.datetime_to_epoch"):
         events = ca_client.get(dummy_pv, datetime.now(), datetime.now(), 2)
     assert events == [event_1d]

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -56,6 +56,7 @@ def test_AaFetcher_constructs_url_correctly(dummy_pv, aa_fetcher):
         aa_fetcher.get_values(dummy_pv, early, late, None)
         expected = (
             "dummy-url?pv=dummy&from=2001-01-01T01:01:00Z&to=2010-02-03T04:05:00Z"
+            "&fetchLatestMetadata=true"
         )
         assert mock_get.call_args[0][0] == expected
         mock_get.reset_mock()
@@ -64,7 +65,11 @@ def test_AaFetcher_constructs_url_correctly(dummy_pv, aa_fetcher):
         request_params["param1Name"] = "param1Value"
         request_params["param2Name"] = "param2Value"
         aa_fetcher.get_values(dummy_pv, early, late, None, request_params)
-        expected += "&param1Name=param1Value&param2Name=param2Value"
+        expected = (
+            "dummy-url?pv=dummy&from=2001-01-01T01:01:00Z&to=2010-02-03T04:05:00Z"
+            "&param1Name=param1Value&param2Name=param2Value"
+            "&fetchLatestMetadata=true"
+        )
         assert mock_get.call_args[0][0] == expected
 
 

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -55,7 +55,6 @@ def test_JsonFetcher_decodes_string_event_correctly(dummy_pv, json_fetcher):
     mock_response = utils.mock_response(json_str=event_json)
     json_fetcher._fetch_data = mock.MagicMock(return_value=mock_response)
     aa_data = json_fetcher.get_values(dummy_pv, EARLY_DATE, LATE_DATE)
-    print(aa_data)
     assert aa_data.pv == dummy_pv
     assert aa_data.values[0] == "2015-01-08 19:47:01 UTC"
     assert aa_data.timestamps[0] == 1507712433.235971000
@@ -70,3 +69,16 @@ def test_JsonFetcher_decodes_waveform_events_correctly(
     json_fetcher._fetch_data = mock.MagicMock(return_value=mock_response)
     aa_data = json_fetcher.get_values(dummy_pv, EARLY_DATE, LATE_DATE)
     assert aa_data == data_2d_2_events
+
+
+def test_JsonFetcher_decodes_enum_events_correctly(
+    dummy_pv, json_fetcher,
+):
+    enum_json = utils.load_from_file("enum_event.json")
+    mock_response = utils.mock_response(json_str=enum_json)
+    json_fetcher._fetch_data = mock.MagicMock(return_value=mock_response)
+    aa_data = json_fetcher.get_values(dummy_pv, EARLY_DATE, LATE_DATE)
+    assert aa_data.enum_options[5] == "Special"
+    assert aa_data.enum_strings[0] == "User"
+    assert aa_data[0].enum_string[0] == "User"
+    assert aa_data.values[0] == 4

--- a/tests/test_pb.py
+++ b/tests/test_pb.py
@@ -25,7 +25,7 @@ RAW_EVENT = (
 # The contents of a PB file with a header and one event.
 PB_CHUNK = RAW_PAYLOAD_INFO + b"\n" + RAW_EVENT
 # The actual contents of the above raw strings (PV name is not stored)
-EVENT = data.ArchiveEvent(PV, 264.65571148, 1422752399.004147078, 0)
+EVENT = data.ArchiveEvent(PV, [264.65571148], 1422752399.004147078, 0)
 
 
 def test_parse_PayloadInfo():
@@ -38,7 +38,7 @@ def test_parse_PayloadInfo():
 def test_parse_ScalarDouble():
     e = ee.ScalarDouble()
     e.ParseFromString(RAW_EVENT)
-    assert abs(e.val - EVENT.value) < 1e-7
+    assert abs(e.val - EVENT.value[0]) < 1e-7
     year_timestamp = utils.year_timestamp(2015)
     assert year_timestamp + e.secondsintoyear + 1e-9 * e.nano == EVENT.timestamp
     assert e.severity == EVENT.severity
@@ -112,6 +112,7 @@ def test_PbFetcher_get_calls_get_with_correct_url(dummy_pv, jan_2018):
         expected_url = (
             "http://dummy.com:8000/retrieval/data/getData.raw"
             "?pv=dummy&from=2018-01-01T00:00:00Z&to=2018-01-01T00:00:00Z"
+            "&fetchLatestMetadata=true"
         )
         mock_get.assert_called_with(expected_url, stream=True)
 

--- a/tests/test_pb.py
+++ b/tests/test_pb.py
@@ -1,6 +1,7 @@
 import os
 
 import mock
+import numpy
 import pytest
 import requests
 import utils as testutils
@@ -25,7 +26,7 @@ RAW_EVENT = (
 # The contents of a PB file with a header and one event.
 PB_CHUNK = RAW_PAYLOAD_INFO + b"\n" + RAW_EVENT
 # The actual contents of the above raw strings (PV name is not stored)
-EVENT = data.ArchiveEvent(PV, [264.65571148], 1422752399.004147078, 0)
+EVENT = data.ArchiveEvent(PV, numpy.array([264.65571148]), 1422752399.004147078, 0)
 
 
 def test_parse_PayloadInfo():


### PR DESCRIPTION
- Add `fetchLatestMetadata=true` to all requests.

- Parse the resulting metadata looking for enum options in PB and JSON responses.

- Add `enum_options` member to `ArchiveData`. Populate an `enum_strings` array for enum string of each value, if available.

- Add `enum_string` member to `ArchiveEvent`.

Please could you have a go with it and see if presentation of the information is useful?