### PR TITLE
Add REST calls to get appliance and cluster metrics

### DIFF
--- a/aa/rest.py
+++ b/aa/rest.py
@@ -136,3 +136,11 @@ class AaRestClient(object):
             samplingperiod=period,
             samplingmethod=method.upper(),
         )
+
+    def get_appliance_metrics(self):
+        """Gives summary metrics for all appliances in cluster"""
+        return self._rest_get("getApplianceMetrics")
+
+    def get_appliance_metrics_for_appliance(self, appliance):
+        """Gives detailed metrics for the appliance on the specified host"""
+        return self._rest_get("getApplianceMetricsForAppliance", appliance=appliance)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -42,6 +42,12 @@ def test_AaRestClient_construct_url(kwargs, aa_client):
         ("resumeArchivingPV", "resume_archiving_pv", {"pv": "dummy"}),
         ("deletePV", "delete_pv", {"pv": "dummy"}),
         ("abortArchivingPV", "abort_archiving_pv", {"pv": "dummy"}),
+        ("getApplianceMetrics", "get_appliance_metrics", {}),
+        (
+            "getApplianceMetricsForAppliance",
+            "get_appliance_metrics_for_appliance",
+            {"appliance": "dummy_host"},
+        ),
     ],
 )
 @mock.patch("requests.get")


### PR DESCRIPTION
Add AaRestClient.get_appliance_metrics for cluster
summary metrics and
AaRestClient.get_appliance_metrics_for_appliance for detailed
individual appliance metrics.

I have kept the names the same as the API calls although they aren't very descriptive.

Required for a monitoring application.