### PR TITLE
Add renamePV method to AA rest client

### DIFF
--- a/aa/rest.py
+++ b/aa/rest.py
@@ -144,3 +144,7 @@ class AaRestClient(object):
     def get_appliance_metrics_for_appliance(self, appliance):
         """Gives detailed metrics for the appliance on the specified host"""
         return self._rest_get("getApplianceMetricsForAppliance", appliance=appliance)
+
+    def rename_pv(self, pv: str, newname: str):
+        """Rename pv to newname. The PV needs to be paused first."""
+        return self._rest_get("renamePV", pv=pv, newname=newname)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -48,6 +48,7 @@ def test_AaRestClient_construct_url(kwargs, aa_client):
             "get_appliance_metrics_for_appliance",
             {"appliance": "dummy_host"},
         ),
+        ("renamePV", "rename_pv", {"pv": "dummy1", "newname": "dummy2"}),
     ],
 )
 @mock.patch("requests.get")


### PR DESCRIPTION
Tested against the test server.

This is a very thin API and e.g. like other methods, we defer handling error conditions to the caller.