### PR TITLE
Add get_policy_list to AaRestClient

### DIFF
--- a/aa/rest.py
+++ b/aa/rest.py
@@ -148,3 +148,10 @@ class AaRestClient(object):
     def rename_pv(self, pv: str, newname: str):
         """Rename pv to newname. The PV needs to be paused first."""
         return self._rest_get("renamePV", pv=pv, newname=newname)
+
+    def get_policy_list(self):
+        """Get the list of available archiving policies
+
+        Note this is not part of the documented BPL API.
+        """
+        return self._rest_get("getPolicyList")

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -49,6 +49,7 @@ def test_AaRestClient_construct_url(kwargs, aa_client):
             {"appliance": "dummy_host"},
         ),
         ("renamePV", "rename_pv", {"pv": "dummy1", "newname": "dummy2"}),
+        ("getPolicyList", "get_policy_list", {}),
     ],
 )
 @mock.patch("requests.get")


### PR DESCRIPTION
Returns the list of available archiving policies.

Note this is not part of the documented API but it is used by the web front end.

cc @MJGaughran 